### PR TITLE
use `type -p` to detect if valet is installed/in the path.

### DIFF
--- a/switch-php.sh
+++ b/switch-php.sh
@@ -150,7 +150,7 @@ fi
 
 # Let's check and see if Valet is installed
 [ $verbose -eq 1 ] && printf " 👀  Verifying that Valet is installed...\n" # If $verbose, then echo
-valet &>/dev/null && valet_installed=1 || valet_installed=0 # Let's store the outcome in a variable
+type -p valet &>/dev/null && valet_installed=1 || valet_installed=0 # Let's store the outcome in a variable
 
 
 # Let's check and see which PHP versions are installed


### PR DESCRIPTION
Better supports situations where a php@$ver is installated and possibly broken, which would then make the command `valet` fail.